### PR TITLE
Add standalone assertions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,3 +21,4 @@
 ^\.covrignore$
 ^\.github$
 \.*gcov$
+^_pkgdown\.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,11 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 URL: https://reside-ic.github.io/reside.utils, https://github.com/reside-ic/reside.utils
 BugReports: https://github.com/reside-ic/reside.utils/issues
+Imports:
+    cli
 Suggests:
     pkgload,
+    rmarkdown,
     usethis,
     testthat (>= 3.0.0),
     withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,5 +15,8 @@ RoxygenNote: 7.1.1
 URL: https://reside-ic.github.io/reside.utils, https://github.com/reside-ic/reside.utils
 BugReports: https://github.com/reside-ic/reside.utils/issues
 Suggests:
-    testthat (>= 3.0.0)
+    pkgload,
+    usethis,
+    testthat (>= 3.0.0),
+    withr
 Config/testthat/edition: 3

--- a/R/standalone-utils-assert.R
+++ b/R/standalone-utils-assert.R
@@ -1,8 +1,8 @@
-## ---
-## repo: reside/reside.utils
-## file: standalone-utils-assert.R
-## imports: cli
-## ---
+# ---
+# repo: reside/reside.utils
+# file: standalone-utils-assert.R
+# imports: cli
+# ---
 assert_scalar <- function(x, name = deparse(substitute(x)), arg = name,
                           call = parent.frame())  {
   if (length(x) != 1) {

--- a/R/standalone-utils-assert.R
+++ b/R/standalone-utils-assert.R
@@ -1,0 +1,175 @@
+## ---
+## repo: reside/reside.utils
+## file: standalone-utils-assert.R
+## imports: cli
+## ---
+assert_scalar <- function(x, name = deparse(substitute(x)), arg = name,
+                          call = parent.frame())  {
+  if (length(x) != 1) {
+    cli::cli_abort(
+      c("'{name}' must be a scalar",
+        i = "{name} has length {length(x)}"),
+      call = call, arg = arg)
+  }
+  invisible(x)
+}
+
+
+assert_character <- function(x, name = deparse(substitute(x)),
+                             arg = name, call = parent.frame()) {
+  if (!is.character(x)) {
+    cli::cli_abort("Expected '{name}' to be character", call = call, arg = arg)
+  }
+  invisible(x)
+}
+
+
+assert_numeric <- function(x, name = deparse(substitute(x)),
+                           arg = name, call = parent.frame()) {
+  if (!is.numeric(x)) {
+    cli::cli_abort("Expected '{name}' to be numeric", call = call, arg = arg)
+  }
+  invisible(x)
+}
+
+
+assert_integer <- function(x, name = deparse(substitute(x)),
+                           tolerance = NULL, arg = name,
+                           call = parent.frame()) {
+  if (is.numeric(x)) {
+    rx <- round(x)
+    if (is.null(tolerance)) {
+      tolerance <- sqrt(.Machine$double.eps)
+    }
+    if (!isTRUE(all.equal(x, rx, tolerance = tolerance))) {
+      cli::cli_abort(
+        c("Exected '{name}' to be integer",
+          i = paste("{cli::qty(length(x))}The provided",
+                    "{?value was/values were} numeric, but not very close",
+                    "to integer values")),
+        arg = arg, call = call)
+    }
+    x <- as.integer(rx)
+  } else {
+    cli::cli_abort("Exected '{name}' to be integer", call = call, arg = arg)
+  }
+  invisible(x)
+}
+
+
+assert_logical <- function(x, name = deparse(substitute(x)),
+                          arg = name, call = parent.frame()) {
+  if (!is.logical(x)) {
+    cli::cli_abort("Expected '{name}' to be logical", arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_nonmissing <- function(x, name = deparse(substitute(x)),
+                          arg = name, call = parent.frame()) {
+  if (anyNA(x)) {
+    cli::cli_abort("Expected '{name}' to be non-NA", arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_scalar_character <- function(x, name = deparse(substitute(x)),
+                                  arg = name, call = parent.frame()) {
+  assert_scalar(x, name, arg = arg, call = call)
+  assert_character(x, name, arg = arg, call = call)
+  assert_nonmissing(x, name, arg = arg, call = call)
+}
+
+
+assert_scalar_numeric <- function(x, name = deparse(substitute(x)),
+                                  arg = name, call = parent.frame()) {
+  assert_scalar(x, name, arg = arg, call = call)
+  assert_numeric(x, name, arg = arg, call = call)
+  assert_nonmissing(x, name, arg = arg, call = call)
+}
+
+
+assert_scalar_integer <- function(x, name = deparse(substitute(x)),
+                                  tolerance = NULL, arg = name, call = parent.frame()) {
+  assert_scalar(x, name, arg = arg, call = call)
+  assert_integer(x, name, tolerance = tolerance, arg = arg, call = call)
+  assert_nonmissing(x, name, arg = arg, call = call)
+}
+
+
+assert_scalar_logical <- function(x, name = deparse(substitute(x)),
+                                  arg = name, call = parent.frame()) {
+  assert_scalar(x, name, arg = arg, call = call)
+  assert_logical(x, name, arg = arg, call = call)
+  assert_nonmissing(x, name, arg = arg, call = call)
+}
+
+
+assert_scalar_size <- function(x, allow_zero = TRUE,
+                               name = deparse(substitute(x)),
+                               arg = name, call = parent.frame()) {
+  assert_scalar_integer(x, name = name, arg = arg, call = call)
+  assert_nonmissing(x, name, arg = arg, call = call)
+  min <- if (allow_zero) 0 else 1
+  if (x < min) {
+    cli::cli_abort("'{name}' must be at least {min}", arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_length <- function(x, len, name = deparse(substitute(x)), arg = name,
+                          call = parent.frame()) {
+  if (length(x) != len) {
+    cli::cli_abort(
+      "Expected '{name}' to have length {len}, but was length {length(x)}",
+      arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_is <- function(x, what, name = deparse(substitute(x)), arg = name,
+                      call = parent.frame()) {
+  if (!inherits(x, what)) {
+    cli::cli_abort("Expected '{name}' to be a '{what}' object",
+                   arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
+assert_named <- function(x, unique = FALSE, name = deparse(substitute(x)),
+                         arg = name, call = parent.frame()) {
+  nms <- names(x)
+  if (is.null(nms)) {
+    cli::cli_abort("'{name}' must be named", call = call, arg = arg)
+  }
+  if (anyNA(nms) || any(nms == "")) {
+    cli::cli_abort("All elements of '{name}' must be named",
+                   call = call, arg = arg)
+  }
+  if (unique && anyDuplicated(names(x))) {
+    dups <- sprintf("'%s'", unique(names(x)[duplicated(names(x))]))
+    cli::cli_abort(
+      c("'{name}' must have unique names",
+        i = "Found {length(dups)} duplicate{?s}: {dups}"),
+      call = call, arg = arg)
+  }
+  invisible(x)
+}
+
+
+match_value <- function(x, choices, name = deparse(substitute(x)), arg = name,
+                        call = parent.frame()) {
+  assert_scalar_character(x, call = call, arg = arg)
+  if (!(x %in% choices)) {
+    choices_str <- paste(sprintf("'%s'", choices), collapse = ", ")
+    cli::cli_abort(c("'{name}' must be one of {choices_str}",
+                     i = "Instead we were given '{x}'"), call = call,
+                   arg = arg)
+  }
+  x
+}

--- a/R/standalone-utils-assert.R
+++ b/R/standalone-utils-assert.R
@@ -151,6 +151,35 @@ assert_list <- function(x, name = deparse(substitute(x)), arg = name,
 }
 
 
+assert_scalar_positive_numeric <- function(x, allow_zero = TRUE,
+                                           name = deparse(substitute(x)),
+                                           arg = name, call = parent.frame()) {
+  assert_scalar_numeric(x, name = name, call = call)
+  if (allow_zero) {
+    if (x < 0) {
+      cli::cli_abort("'{name}' must be at least 0", arg = arg, call = call)
+    }
+  } else {
+    if (x <= 0) {
+      cli::cli_abort("'{name}' must be greater than 0", arg = arg, call = call)
+    }
+  }
+  invisible(x)
+}
+
+
+assert_raw <- function(x, len = NULL, name = deparse(substitute(x)),
+                       arg = name, call = parent.frame()) {
+  if (!is.raw(x)) {
+    cli::cli_abort("'{name}' must be a raw vector", arg = arg, call = call)
+  }
+  if (!is.null(len)) {
+    assert_length(x, len, name = name, call = call)
+  }
+  invisible(x)
+}
+
+
 assert_named <- function(x, unique = FALSE, name = deparse(substitute(x)),
                          arg = name, call = parent.frame()) {
   nms <- names(x)

--- a/R/standalone-utils-assert.R
+++ b/R/standalone-utils-assert.R
@@ -141,6 +141,16 @@ assert_is <- function(x, what, name = deparse(substitute(x)), arg = name,
 }
 
 
+assert_list <- function(x, name = deparse(substitute(x)), arg = name,
+                        call = parent.frame()) {
+  if (!is.list(x)) {
+    cli::cli_abort("Expected '{name}' to be a list",
+                   arg = arg, call = call)
+  }
+  invisible(x)
+}
+
+
 assert_named <- function(x, unique = FALSE, name = deparse(substitute(x)),
                          arg = name, call = parent.frame()) {
   nms <- names(x)

--- a/R/standalone-utils-assert.R
+++ b/R/standalone-utils-assert.R
@@ -43,7 +43,7 @@ assert_integer <- function(x, name = deparse(substitute(x)),
     }
     if (!isTRUE(all.equal(x, rx, tolerance = tolerance))) {
       cli::cli_abort(
-        c("Exected '{name}' to be integer",
+        c("Expected '{name}' to be integer",
           i = paste("{cli::qty(length(x))}The provided",
                     "{?value was/values were} numeric, but not very close",
                     "to integer values")),
@@ -51,7 +51,7 @@ assert_integer <- function(x, name = deparse(substitute(x)),
     }
     x <- as.integer(rx)
   } else {
-    cli::cli_abort("Exected '{name}' to be integer", call = call, arg = arg)
+    cli::cli_abort("Expected '{name}' to be integer", call = call, arg = arg)
   }
   invisible(x)
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Usage
 
 ```r
-usethis::use_standalone("reside-ic/reside.utils", "standalone-utils-assert.R")
+usethis::use_standalone("reside-ic/reside.utils", "utils-assert")
 ```
 
 To exclude this file from coverage counts, make a `.covrignore` file containing:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@
 [![codecov.io](https://codecov.io/github/mrc-ide/reside.utils/coverage.svg?branch=main)](https://codecov.io/github/mrc-ide/reside.utils?branch=main)
 <!-- badges: end -->
 
+## Usage
+
+```r
+usethis::use_standalone("reside-ic/reside.utils", "standalone-utils-assert.R")
+```
+
+To exclude this file from coverage counts, make a `.covrignore` file containing:
+
+```
+R/import-*.R
+```
+
+To exclude these files from GitHub diffs by default
+
+```
+R/import-*.R linguist-generated=true
+```
+
 ## Installation
 
 To install `reside.utils`:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://reside-ic.github.io/reside.utils
+
+template:
+  bootstrap: 5

--- a/tests/testthat/test-util-assert.R
+++ b/tests/testthat/test-util-assert.R
@@ -1,0 +1,105 @@
+test_that("assert_is", {
+  x <- structure(list(), class = "foo")
+  expect_silent(assert_is(x, "foo"))
+  expect_error(assert_is(x, "bar"),
+               "Expected 'x' to be a 'bar'")
+})
+
+
+test_that("assert_scalar", {
+  expect_error(assert_scalar(NULL), "must be a scalar")
+  expect_error(assert_scalar(numeric(0)), "must be a scalar")
+  expect_error(assert_scalar(1:2), "must be a scalar")
+})
+
+
+test_that("assert_character", {
+  expect_silent(assert_character("a"))
+  expect_error(assert_character(1), "to be character")
+  expect_error(assert_character(TRUE), "to be character")
+})
+
+
+test_that("assert_logical", {
+  expect_silent(assert_logical(TRUE))
+  expect_error(assert_logical(1), "to be logical")
+  expect_error(assert_logical("TRUE"), "to be logical")
+})
+
+
+test_that("assert_nonmissing", {
+  expect_silent(assert_nonmissing(TRUE))
+  expect_error(assert_nonmissing(NA), "Expected 'NA' to be non-NA")
+  x <- c(1, NA)
+  expect_error(assert_nonmissing(x), "Expected 'x' to be non-NA")
+})
+
+
+test_that("assert_numeric", {
+  expect_silent(assert_numeric(1))
+  expect_error(assert_numeric("1"), "to be numeric")
+  expect_error(assert_numeric(TRUE), "to be numeric")
+})
+
+
+test_that("assert_integer", {
+  expect_silent(assert_integer(1))
+  expect_error(assert_integer(1.1), "to be integer")
+  expect_error(assert_integer("1"), "to be integer")
+  expect_error(assert_integer(TRUE), "to be integer")
+})
+
+
+test_that("assert_scalar_size", {
+  expect_silent(assert_scalar_size(10))
+  x <- -4
+  expect_error(assert_scalar_size(x),
+               "'x' must be at least 0")
+  expect_error(assert_scalar_size(x, allow_zero = FALSE),
+               "'x' must be at least 1")
+  x <- 0
+  expect_silent(assert_scalar_size(x))
+  expect_error(assert_scalar_size(x, allow_zero = FALSE),
+               "'x' must be at least 1")
+})
+
+
+test_that("assert_length", {
+  x <- 1:5
+  expect_silent(assert_length(x, 5))
+  expect_error(assert_length(x, 10),
+               "Expected 'x' to have length 10, but was length 5")
+})
+
+
+test_that("assert_named", {
+  expect_silent(assert_named(structure(1:5, names = letters[1:5])))
+  x <- 1:5
+  expect_error(assert_named(x), "'x' must be named")
+  names(x)[1:2] <- c("a", "b")
+  expect_error(assert_named(x), "All elements of 'x' must be named")
+  names(x)[3:5] <- ""
+  expect_error(assert_named(x), "All elements of 'x' must be named")
+  names(x)[3:5] <- c("a", "b", "c")
+  expect_error(assert_named(x, unique = TRUE),
+               "'x' must have unique names")
+  expect_no_error(assert_named(x))
+})
+
+
+test_that("match_value", {
+  expect_error(match_value("foo", letters), "must be one of")
+  expect_silent(match_value("a", letters))
+})
+
+
+test_that("assert_scalar_numeric", {
+  expect_no_error(assert_scalar_numeric(1))
+  expect_error(assert_scalar_numeric(1:2), "must be a scalar")
+})
+
+
+test_that("assert_scalar_logical", {
+  expect_no_error(assert_scalar_logical(TRUE))
+  expect_error(assert_scalar_logical(1), "to be logical")
+})

--- a/tests/testthat/test-util-assert.R
+++ b/tests/testthat/test-util-assert.R
@@ -103,3 +103,11 @@ test_that("assert_scalar_logical", {
   expect_no_error(assert_scalar_logical(TRUE))
   expect_error(assert_scalar_logical(1), "to be logical")
 })
+
+
+test_that("assert_list", {
+  expect_silent(assert_list(list()))
+  expect_silent(assert_list(list(a = 1)))
+  x <- c(a = 1)
+  expect_error(assert_list(x), "Expected 'x' to be a list")
+})

--- a/tests/testthat/test-util-assert.R
+++ b/tests/testthat/test-util-assert.R
@@ -111,3 +111,31 @@ test_that("assert_list", {
   x <- c(a = 1)
   expect_error(assert_list(x), "Expected 'x' to be a list")
 })
+
+
+test_that("assert_raw", {
+  x <- raw(10)
+  expect_silent(assert_raw(x))
+  expect_silent(assert_raw(x, 10))
+  expect_error(assert_raw(x, 5),
+               "Expected 'x' to have length 5, but was length 10")
+  x <- NULL
+  expect_error(assert_raw(x, 5),
+               "'x' must be a raw vector")
+})
+
+
+test_that("assert_scalar_positive numeric", {
+  x <- 1
+  expect_silent(assert_scalar_positive_numeric(x))
+  expect_silent(assert_scalar_positive_numeric(x, allow_zero = FALSE))
+  x <- 0
+  expect_silent(assert_scalar_positive_numeric(x))
+  expect_error(assert_scalar_positive_numeric(x, allow_zero = FALSE),
+               "'x' must be greater than 0")
+  x <- -2
+  expect_error(assert_scalar_positive_numeric(x),
+               "'x' must be at least 0")
+  expect_error(assert_scalar_positive_numeric(x, allow_zero = FALSE),
+               "'x' must be greater than 0")
+})

--- a/tests/testthat/test-zzz-standalone.R
+++ b/tests/testthat/test-zzz-standalone.R
@@ -1,0 +1,23 @@
+test_that("can use utils in standalone", {
+  testthat::skip_if_offline()
+  path <- withr::local_tempdir()
+  writeLines(c(
+    "Package: pkg",
+    "Version: 1.0.0"),
+    file.path(path, "DESCRIPTION"))
+  file.create(file.path(path, "NAMESPACE"))
+  dir.create(file.path(path, "R"))
+
+  evaluate_promise(
+    usethis::with_project(
+      path,
+      usethis::use_standalone("reside-ic/reside.utils",
+                              "standalone-utils-assert.R",
+                              ref = "prototype")))
+
+  expect_true(
+    file.exists(file.path(path, "R/import-standalone-utils-assert.R")))
+
+  pkg <- pkgload::load_all(path, quiet = TRUE)
+  expect_no_error(pkg$env$assert_scalar_logical(TRUE))
+})

--- a/tests/testthat/test-zzz-standalone.R
+++ b/tests/testthat/test-zzz-standalone.R
@@ -11,9 +11,8 @@ test_that("can use utils in standalone", {
   evaluate_promise(
     usethis::with_project(
       path,
-      usethis::use_standalone("reside-ic/reside.utils",
-                              "standalone-utils-assert.R",
-                              ref = "prototype")))
+      usethis::use_standalone("reside-ic/reside.utils", "utils-assert",
+                              ref = "prototype"))) # TODO: drop on merge
 
   expect_true(
     file.exists(file.path(path, "R/import-standalone-utils-assert.R")))

--- a/tests/testthat/test-zzz-standalone.R
+++ b/tests/testthat/test-zzz-standalone.R
@@ -11,8 +11,7 @@ test_that("can use utils in standalone", {
   evaluate_promise(
     usethis::with_project(
       path,
-      usethis::use_standalone("reside-ic/reside.utils", "utils-assert",
-                              ref = "prototype"))) # TODO: drop on merge
+      usethis::use_standalone("reside-ic/reside.utils", "utils-assert")))
 
   expect_true(
     file.exists(file.path(path, "R/import-standalone-utils-assert.R")))


### PR DESCRIPTION
This package bundles up the most recent copy of assertions, as used in odin etc, in a form that we can reuse them elsewhere without needing a dependency (and the complex CRAN interactions that will require when we improve things)

For usage, see:
* https://github.com/mrc-ide/odin2/pull/33
* https://github.com/mrc-ide/monty/pull/67
* https://github.com/mrc-ide/dust2/pull/67