### PR TITLE
Add standalone installation helpers

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,5 @@
 ^\.github$
 \.*gcov$
 ^_pkgdown\.yml$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/R/standalone-install.R
+++ b/R/standalone-install.R
@@ -34,6 +34,7 @@ install_missing <- function(packages,
     if (tolower(ans) == "y") {
       utils::install.packages(msg)
       install_missing(msg, FALSE, call)
+      return()
     }
   }
 

--- a/R/standalone-install.R
+++ b/R/standalone-install.R
@@ -3,7 +3,7 @@
 # file: standalone-install.R
 # imports: [cli, rlang]
 # ---
-install_needed <- function(package, need, offer_install = interactive(),
+install_needed <- function(package, need, offer_install = NULL,
                            call = parent.frame()) {
   packages <- install_needs_list(package, need)
   install_missing(packages, offer_install, call)
@@ -18,7 +18,7 @@ install_needs_list <- function(package, need) {
 
 
 install_missing <- function(packages,
-                            offer_install = interactive(),
+                            offer_install = NULL,
                             call = parent.frame()) {
   err <- !vapply(packages, requireNamespace, TRUE, quietly = TRUE)
   if (!any(err)) {
@@ -28,7 +28,7 @@ install_missing <- function(packages,
   msg <- packages[err]
   message <- "Package{?s} missing for this functionality: {.pkg {msg}}"
 
-  if (offer_install) {
+  if (install_offer_install(offer_install)) {
     cli::cli_alert_warning(message)
     ans <- readline("Try installing these packages? [y/N] ")
     if (tolower(ans) == "y") {
@@ -45,4 +45,13 @@ install_missing <- function(packages,
       i = paste("You can install {cli::qty(n)}{?this package/these packages}",
                 "using {.run {cmd}}")),
     call = call)
+}
+
+
+install_offer_install <- function(offer_install) {
+  if (is.null(offer_install)) {
+    offer_install <- rlang::is_interactive() &&
+      isTRUE(as.logical(Sys.getenv("NOT_CRAN", "false")))
+  }
+  offer_install
 }

--- a/R/standalone-install.R
+++ b/R/standalone-install.R
@@ -34,6 +34,7 @@ install_missing <- function(packages,
     if (tolower(ans) == "y") {
       utils::install.packages(msg)
       install_missing(msg, FALSE, call)
+      cli::cli_alert_success("Installation successful")
       return()
     }
   }

--- a/R/standalone-install.R
+++ b/R/standalone-install.R
@@ -13,27 +13,35 @@ install_needed <- function(package, need, offer_install = NULL,
 install_needs_list <- function(package, need) {
   desc <- utils::packageDescription(package)
   key <- sprintf("Config/Needs/%s", need)
-  strsplit(desc[[key]], ",\\s+")[[1]]
+  value <- desc[[key]]
+  if (is.null(value)) character() else strsplit(value, ",\\s+")[[1]]
+}
+
+
+install_list_missing_packages <- function(packages) {
+  packages[!vapply(packages, requireNamespace, TRUE, quietly = TRUE)]
 }
 
 
 install_missing <- function(packages,
                             offer_install = NULL,
                             call = parent.frame()) {
-  err <- !vapply(packages, requireNamespace, TRUE, quietly = TRUE)
-  if (!any(err)) {
+  msg <- install_list_missing_packages(packages)
+  if (length(msg) == 0) {
     return()
   }
 
-  msg <- packages[err]
   message <- "Package{?s} missing for this functionality: {.pkg {msg}}"
 
   if (install_offer_install(offer_install)) {
     cli::cli_alert_warning(message)
     ans <- readline("Try installing these packages? [y/N] ")
     if (tolower(ans) == "y") {
-      utils::install.packages(msg)
-      install_missing(msg, FALSE, call)
+      msg <- install_packages(msg)
+      if (length(msg) > 0) {
+        cli::cli_abort(
+          "Failed to install package{?s}: {.pkg {msg}}")
+      }
       cli::cli_alert_success("Installation successful")
       return()
     }
@@ -56,4 +64,10 @@ install_offer_install <- function(offer_install) {
       isTRUE(as.logical(Sys.getenv("NOT_CRAN", "false")))
   }
   offer_install
+}
+
+
+install_packages <- function(packages) {
+  utils::install.packages(packages)
+  install_list_missing_packages(packages)
 }

--- a/R/standalone-install.R
+++ b/R/standalone-install.R
@@ -1,0 +1,48 @@
+# ---
+# repo: reside/reside.utils
+# file: standalone-install.R
+# imports: [cli, rlang]
+# ---
+install_needed <- function(package, need, offer_install = interactive(),
+                           call = parent.frame()) {
+  packages <- install_needs_list(package, need)
+  install_missing(packages, offer_install, call)
+}
+
+
+install_needs_list <- function(package, need) {
+  desc <- utils::packageDescription(package)
+  key <- sprintf("Config/Needs/%s", need)
+  strsplit(desc[[key]], ",\\s+")[[1]]
+}
+
+
+install_missing <- function(packages,
+                            offer_install = interactive(),
+                            call = parent.frame()) {
+  err <- !vapply(packages, requireNamespace, TRUE, quietly = TRUE)
+  if (!any(err)) {
+    return()
+  }
+
+  msg <- packages[err]
+  message <- "Package{?s} missing for this functionality: {.pkg {msg}}"
+
+  if (offer_install) {
+    cli::cli_alert_warning(message)
+    ans <- readline("Try installing these packages? [y/N] ")
+    if (tolower(ans) == "y") {
+      utils::install.packages(msg)
+      install_missing(msg, FALSE, call)
+    }
+  }
+
+  cmd <- sprintf("utils::install.packages(c(%s))",
+                 paste(sprintf('"%s"', msg), collapse = ", "))
+  n <- length(msg)
+  cli::cli_abort(
+    c("Package{?s} missing for this functionality: {.pkg {msg}}",
+      i = paste("You can install {cli::qty(n)}{?this package/these packages}",
+                "using {.run {cmd}}")),
+    call = call)
+}

--- a/R/standalone-install.R
+++ b/R/standalone-install.R
@@ -1,7 +1,7 @@
 # ---
 # repo: reside/reside.utils
 # file: standalone-install.R
-# imports: [cli, rlang]
+# imports: cli
 # ---
 install_needed <- function(package, need, offer_install = NULL,
                            call = parent.frame()) {
@@ -52,7 +52,7 @@ install_missing <- function(packages,
 
 install_offer_install <- function(offer_install) {
   if (is.null(offer_install)) {
-    offer_install <- rlang::is_interactive() &&
+    offer_install <- interactive() &&
       isTRUE(as.logical(Sys.getenv("NOT_CRAN", "false")))
   }
   offer_install

--- a/reside.utils.Rproj
+++ b/reside.utils.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -19,3 +19,85 @@ test_that("validate default for installation", {
   })
   mockery::expect_called(mock_interactive, 4)
 })
+
+
+test_that("can read package requirements", {
+  desc <- structure(list(Package = "foo",
+                         "Config/Needs/this" = "a",
+                         "Config/Needs/that" = "a, b, c"),
+                    class = "packageDescription")
+  mock_pkg_description <- mockery::mock(desc, cycle = TRUE)
+  mockery::stub(install_needs_list, "utils::packageDescription",
+                mock_pkg_description)
+  expect_equal(install_needs_list("foo", "this"), "a")
+  expect_equal(install_needs_list("foo", "that"), c("a", "b", "c"))
+  expect_equal(install_needs_list("foo", "other"), character())
+})
+
+
+test_that("can install missing packages", {
+  mock_list_missing_packages <- mockery::mock(c("a", "c"), character())
+  mock_readline <- mockery::mock("y")
+  mock_install_packages <- mockery::mock()
+
+  mockery::stub(install_missing, "install_list_missing_packages",
+                mock_list_missing_packages)
+  mockery::stub(install_missing, "install_packages",
+                mock_install_packages)
+  mockery::stub(install_missing, "readline", mock_readline)
+
+  res <- evaluate_promise(install_missing(c("a", "b", "c"), TRUE))
+  expect_null(res$result)
+  expect_length(res$messages, 2)
+  expect_match(res$messages[[1]],
+               "Packages missing for this functionality: a and c")
+  expect_match(res$messages[[2]],
+               "Installation successful")
+
+  mockery::expect_called(mock_readline, 1)
+  mockery::expect_called(mock_install_packages, 1)
+  expect_equal(mockery::mock_args(mock_install_packages)[[1]],
+               list(c("a", "c")))
+})
+
+
+test_that("can error if installation refused", {
+  mock_list_missing_packages <- mockery::mock(c("a", "c"))
+  mock_readline <- mockery::mock("n")
+  mock_install_packages <- mockery::mock()
+
+  mockery::stub(install_missing, "install_list_missing_packages",
+                mock_list_missing_packages)
+  mockery::stub(install_missing, "install_packages",
+                mock_install_packages)
+  mockery::stub(install_missing, "readline", mock_readline)
+
+  expect_error(
+    suppressMessages(install_missing(c("a", "b", "c"), TRUE)),
+    "Packages missing for this functionality: a and c")
+
+  mockery::expect_called(mock_readline, 1)
+  mockery::expect_called(mock_install_packages, 0)
+})
+
+
+test_that("can error if installation fails", {
+  mock_list_missing_packages <- mockery::mock(c("a", "c"))
+  mock_readline <- mockery::mock("y")
+  mock_install_packages <- mockery::mock("c")
+
+  mockery::stub(install_missing, "install_list_missing_packages",
+                mock_list_missing_packages)
+  mockery::stub(install_missing, "install_packages",
+                mock_install_packages)
+  mockery::stub(install_missing, "readline", mock_readline)
+
+  expect_error(
+    suppressMessages(install_missing(c("a", "b", "c"), TRUE)),
+    "Failed to install package")
+
+  mockery::expect_called(mock_readline, 1)
+  mockery::expect_called(mock_install_packages, 1)
+  expect_equal(mockery::mock_args(mock_install_packages)[[1]],
+               list(c("a", "c")))
+})

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,0 +1,21 @@
+test_that("validate default for installation", {
+  skip_if_not_installed("mockery")
+  mock_interactive <- mockery::mock(TRUE, FALSE, cycle = TRUE)
+  mockery::stub(install_offer_install, "interactive", mock_interactive)
+
+  expect_true(install_offer_install(TRUE))
+  expect_false(install_offer_install(FALSE))
+  mockery::expect_called(mock_interactive, 0)
+
+  withr::with_envvar(c(NOT_CRAN = NA_character_), {
+    expect_false(install_offer_install(NULL))
+    expect_false(install_offer_install(NULL))
+  })
+  mockery::expect_called(mock_interactive, 2)
+
+  withr::with_envvar(c(NOT_CRAN = "TRUE"), {
+    expect_true(install_offer_install(NULL))
+    expect_false(install_offer_install(NULL))
+  })
+  mockery::expect_called(mock_interactive, 4)
+})


### PR DESCRIPTION
This is a new set of standalone helpers that will allow us to use the tidyverse style "Config/Needs/thing" approach in DESCRIPTION then use a little standalone helper to install packages.  So for dust we'll use it for the compile dependencies, and for hipercow we can use it if we have some deps that are optional (e.g., bits for rrq).

At present it assumes that we can install things with `install.packages` but installation with remotes would allow for finding things from alternative locations.

Used in https://github.com/mrc-ide/dust2/pull/87/files